### PR TITLE
Feature/#8 resolve path set alias

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,7 @@ module.exports = {
       tsConfig: "tsconfig.test.json",
     },
   },
+  moduleNameMapper: {
+    "src/(.*)": "<rootDir>/src/$1",
+  },
 };

--- a/src/FecApiWrapper/index.ts
+++ b/src/FecApiWrapper/index.ts
@@ -1,5 +1,5 @@
 import { TokenGuard } from "./TokenGuard";
-import { CONSTVALUES } from "../config";
+import { CONSTVALUES } from "src/config";
 import {
   // eslint-disable-next-line no-unused-vars
   AuthPostResponse,

--- a/src/components/AuthContainer/index.tsx
+++ b/src/components/AuthContainer/index.tsx
@@ -4,6 +4,7 @@ import { Paper } from "@material-ui/core";
 import { LoginContainer } from "../LoginContainer";
 import { CreateContainer } from "../CreateContainer";
 import { ToggleDisplayContainer } from "../ToggleDisplayContainer";
+
 import { useStyles } from "./style";
 
 interface AuthContainerProps {

--- a/src/components/CreateContainer/CreateContainer.tsx
+++ b/src/components/CreateContainer/CreateContainer.tsx
@@ -1,10 +1,11 @@
 import React, { memo, useState, useCallback, useMemo } from "react";
 import update from "immutability-helper";
 
+import { FecApiWrapper, isBadResponse } from "src/FecApiWrapper";
+import { useCurrent, useApi, useVariable } from "src/customhook";
+
 // eslint-disable-next-line no-unused-vars
 import { CreateForm, Infos, warning } from "./CreateForm";
-import { FecApiWrapper, isBadResponse } from "../../FecApiWrapper";
-import { useCurrent, useApi, useVariable } from "../../customhook";
 
 interface CreateContainerProps extends BaseComponentProps {
   className?: string;

--- a/src/components/CreateContainer/CreateForm.tsx
+++ b/src/components/CreateContainer/CreateForm.tsx
@@ -2,13 +2,12 @@ import React, { memo, useRef, useCallback } from "react";
 import { Grid, Button } from "@material-ui/core";
 
 // eslint-disable-next-line no-unused-vars
-import { WarningState, warning } from "./WarningState";
 import { ValidateEmailInput } from "../ValidateEmailInput";
 import { ValidatePasswordInput } from "../ValidatePasswordInput";
 import { ValidateNameInput } from "../ValidateNameInput";
+import { useVariable } from "src/customhook";
 
-import { useVariable } from "../../customhook";
-
+import { WarningState, warning } from "./WarningState";
 import { useStyles } from "./style";
 
 export interface Infos {

--- a/src/components/CreateContainer/WarningState.tsx
+++ b/src/components/CreateContainer/WarningState.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 
 import { WarningLabel } from "../WarningLabel";
 import { DisplayContainer } from "../DisplayContainer";
-import { useVariable } from "../../customhook";
+import { useVariable } from "src/customhook";
 
 export interface Info {
   email: string;

--- a/src/components/LoginContainer/index.tsx
+++ b/src/components/LoginContainer/index.tsx
@@ -2,11 +2,12 @@ import React, { useRef, useState, useCallback, useMemo, memo } from "react";
 import { Grid, Button } from "@material-ui/core";
 import update from "immutability-helper";
 
-import { useDidMountEffect } from "../../customhook/useDidMountEffect";
 import { ValidateEmailInput } from "../ValidateEmailInput";
 import { ValidatePasswordInput } from "../ValidatePasswordInput";
 import { WarningState } from "./WarningState";
-import { FecApiWrapper } from "../../FecApiWrapper";
+import { FecApiWrapper } from "src/FecApiWrapper";
+import { useDidMountEffect } from "src/customhook";
+
 import { useStyles } from "./style";
 
 type LoginContainerProps = BaseComponentProps;

--- a/src/components/ToggleDisplayContainer/index.tsx
+++ b/src/components/ToggleDisplayContainer/index.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import React, { ReactNode, useMemo, memo } from "react";
+import React, { useMemo, memo } from "react";
 
 interface ToggleDisplayContainerProps extends BaseComponentProps {
   isShownFirstChild: boolean;

--- a/src/components/ToggleEyeIcon/index.tsx
+++ b/src/components/ToggleEyeIcon/index.tsx
@@ -2,6 +2,7 @@ import React, { memo } from "react";
 import Eye from "@material-ui/icons/Visibility";
 import OffEye from "@material-ui/icons/VisibilityOff";
 import { IconButton } from "@material-ui/core";
+
 import { ToggleDisplayContainer } from "../ToggleDisplayContainer";
 
 interface ToggleEyeIconProps extends BaseComponentProps {

--- a/src/components/ValidateEmailInput/index.tsx
+++ b/src/components/ValidateEmailInput/index.tsx
@@ -3,7 +3,6 @@ import Email from "@material-ui/icons/Email";
 
 // eslint-disable-next-line no-unused-vars
 import { ValidateBaseInput } from "../ValidateBaseInput";
-// eslint-disable-next-line no-unused-vars
 
 const label = "Email";
 

--- a/src/customhook/useAbortableEffect.ts
+++ b/src/customhook/useAbortableEffect.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line no-unused-vars
 import React, { useEffect, useRef, useCallback } from "react";
+
 import { useMountedState } from ".";
 
 // abort when unmount

--- a/src/customhook/useApi.ts
+++ b/src/customhook/useApi.ts
@@ -1,7 +1,8 @@
 import React from "react";
-import { useAbortableEffect } from ".";
+
+import { useAbortableEffect } from "src/customhook";
 // eslint-disable-next-line no-unused-vars
-import { FecApiWrapper } from "../FecApiWrapper";
+import { FecApiWrapper } from "src/FecApiWrapper";
 
 export const useApi = (
   func: (isMounted: () => boolean, didMounted: () => boolean) => any,

--- a/src/customhook/useCurrent.ts
+++ b/src/customhook/useCurrent.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React, { useMemo } from "react";
 
 export const useCurrent = <T>(

--- a/src/customhook/useMountedState.ts
+++ b/src/customhook/useMountedState.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React, { useRef, useEffect, useCallback } from "react";
 
 export const useMountedState = () => {

--- a/src/customhook/useVariable.ts
+++ b/src/customhook/useVariable.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React, { useMemo } from "react";
 
 export const useVariable = <T>(valiable: T) => {

--- a/tests/CreateContainer.test.tsx
+++ b/tests/CreateContainer.test.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import { render, screen, RenderResult, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { mocked } from "ts-jest/utils";
-import { CreateContainer } from "../src/components/CreateContainer";
-import { FecApiWrapper, isBadResponse } from "../src/FecApiWrapper";
+import { CreateContainer } from "src/components/CreateContainer";
+import { FecApiWrapper, isBadResponse } from "src/FecApiWrapper";
 
 const isBadResponseOrigin = jest.requireActual("../src/FecApiWrapper")
   .isBadResponse;

--- a/tests/DisplayContainer.test.tsx
+++ b/tests/DisplayContainer.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 // eslint-disable-next-line no-unused-vars
 import { render, screen, RenderResult } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { DisplayContainer } from "../src/components/DisplayContainer";
+import { DisplayContainer } from "src/components/DisplayContainer";
 
 const prefix = "this is the ";
 const testcase = "testcase";

--- a/tests/InputPlace.test.tsx
+++ b/tests/InputPlace.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 // eslint-disable-next-line no-unused-vars
 import { render, screen, RenderResult } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { InputPlace } from "../src/components/InputPlace";
+import { InputPlace } from "src/components/InputPlace";
 
 describe("Normal system", () => {
   let inputPlace: RenderResult;

--- a/tests/LoginContainer.test.tsx
+++ b/tests/LoginContainer.test.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import { render, screen, RenderResult, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { mocked } from "ts-jest/utils";
-import { LoginContainer } from "../src/components/LoginContainer";
-import { FecApiWrapper } from "../src/FecApiWrapper";
+import { LoginContainer } from "src/components/LoginContainer";
+import { FecApiWrapper } from "src/FecApiWrapper";
 
 jest.mock("../src/FecApiWrapper");
 

--- a/tests/ToggleDisplayContainer.test.tsx
+++ b/tests/ToggleDisplayContainer.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 // eslint-disable-next-line no-unused-vars
 import { render, screen, RenderResult } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { ToggleDisplayContainer } from "../src/components/ToggleDisplayContainer";
+import { ToggleDisplayContainer } from "src/components/ToggleDisplayContainer";
 
 describe("Normal system", () => {
   let toggleDisplayContainer: RenderResult;

--- a/tests/ToggleEyeIcon.test.tsx
+++ b/tests/ToggleEyeIcon.test.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { render, screen, RenderResult, waitFor } from "@testing-library/react";
 import UserEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ToggleEyeIcon } from "../src/components/ToggleEyeIcon";
+import { ToggleEyeIcon } from "src/components/ToggleEyeIcon";
 
 const excludeNull = function <T>(arg: T) {
   if (arg == null) throw new Error("This value includes null");

--- a/tests/ValidateBaseInput.test.tsx
+++ b/tests/ValidateBaseInput.test.tsx
@@ -8,7 +8,7 @@ import { render, screen, RenderResult } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { act } from "react-dom/test-utils";
 import "@testing-library/jest-dom";
-import { ValidateBaseInput } from "../src/components/ValidateBaseInput";
+import { ValidateBaseInput } from "src/components/ValidateBaseInput";
 
 const excludeNull = function <T>(arg: T) {
   if (arg == null) throw new Error("This value includes null");

--- a/tests/ValidateEmailInput.test.tsx
+++ b/tests/ValidateEmailInput.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, RenderResult } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { act } from "react-dom/test-utils";
 import "@testing-library/jest-dom";
-import { ValidateEmailInput } from "../src/components/ValidateEmailInput";
+import { ValidateEmailInput } from "src/components/ValidateEmailInput";
 
 const excludeNull = function <T>(arg: T) {
   if (arg == null) throw new Error("This value includes null");

--- a/tests/ValidateNameInput.test.tsx
+++ b/tests/ValidateNameInput.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, RenderResult } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { act } from "react-dom/test-utils";
 import "@testing-library/jest-dom";
-import { ValidateNameInput } from "../src/components/ValidateNameInput";
+import { ValidateNameInput } from "src/components/ValidateNameInput";
 
 const excludeNull = function <T>(arg: T) {
   if (arg == null) throw new Error("This value includes null");

--- a/tests/ValidatePasswordInput.test.tsx
+++ b/tests/ValidatePasswordInput.test.tsx
@@ -8,7 +8,7 @@ import { mock } from "jest-mock-extended";
 import { act } from "react-dom/test-utils";
 import UserEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ValidatePasswordInput } from "../src/components/ValidatePasswordInput";
+import { ValidatePasswordInput } from "src/components/ValidatePasswordInput";
 
 const excludeNull = function <T>(arg: T) {
   if (arg == null) throw new Error("This value includes null");

--- a/tests/WarningLabel.test.tsx
+++ b/tests/WarningLabel.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 // eslint-disable-next-line no-unused-vars
 import { render, screen, RenderResult } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { WarningLabel } from "../src/components/WarningLabel";
+import { WarningLabel } from "src/components/WarningLabel";
 
 describe("Normal system", () => {
   let warningLabel: RenderResult;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,12 @@
     "noImplicitReturns": true,
     "downlevelIteration": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react"
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "src/*":["*","src/*"]
+    }
   },
   "include": ["./**/*.ts*","./**/*.js"],
   "exclude": ["node_modules","public"]
   }
-  

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,9 @@ const webpackConfig = (env: {
   entry: "./src/index.tsx",
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".css"],
+    alias: {
+      src: path.resolve(__dirname, "src/"),
+    },
   },
   output: {
     path: path.join(__dirname, "/public"),


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#8 の対応
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* パスのエイリアスの設定
* エイリアスの適用
## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->
小規模な変更なので特になし。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
今後のインポート部分の半数以上。
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし。
## 補足
<!-- ローカル環境で試す際の注意点、など -->
typescriptのエイリアスは正規表現でグルーピングしたパスをbaseUrlと連結し、追加のパスの記述があればbaseUrlとキャプチャしたパスの間に挟み込むような形で連結する。
対してjestは正規表現でグルービングしたパスを、事前に用意したテンプレートに当てはめるような形である。
またwebpackは指定の文字列を違う文字列で置き換える形になる。
