### PR TITLE
Feature/#22 refactor form add util

### DIFF
--- a/src/util/components/RefFunctionally.tsx
+++ b/src/util/components/RefFunctionally.tsx
@@ -1,3 +1,7 @@
+// Use if the warning occured.
+// It is like "use createRef or Ref-setter."
+// So, this is to transform RefMutableObject from useRef to Ref-setter.
+
 import React, { memo, useMemo } from "react";
 // eslint-disable-next-line no-unused-vars
 import { HadChildComponentProps, RefComponentProps } from "../types";

--- a/src/util/components/RefFunctionally.tsx
+++ b/src/util/components/RefFunctionally.tsx
@@ -1,0 +1,20 @@
+import React, { memo, useMemo } from "react";
+// eslint-disable-next-line no-unused-vars
+import { HadChildComponentProps, RefComponentProps } from "../types";
+import { getRefSetter } from "..";
+
+const NotYetRefFanctionally = React.forwardRef<
+  unknown,
+  HadChildComponentProps<RefComponentProps>
+>((props, ref) => {
+  const refSetter = useMemo(() => getRefSetter(ref), [ref]);
+  return React.cloneElement(props.children, {
+    ref: refSetter,
+    className: props.className,
+  });
+});
+
+const RefFanctionally = memo(NotYetRefFanctionally);
+RefFanctionally.displayName = "RefFanctionally";
+
+export { RefFanctionally };

--- a/src/util/components/RefPropertyControll.tsx
+++ b/src/util/components/RefPropertyControll.tsx
@@ -1,0 +1,37 @@
+import React, { memo, useEffect, useMemo, useRef } from "react";
+// eslint-disable-next-line no-unused-vars
+import { Ref, HadChildComponentProps, RefComponentProps } from "../types";
+import { decideMutableRef } from "..";
+
+interface RefPropertyControllProps
+  extends HadChildComponentProps<RefComponentProps> {
+  propertyName: string;
+}
+
+const initCurrent = function <T>(current: T) {
+  let initialValue = current;
+  if (current == null) initialValue = {} as T;
+  return initialValue as NonNullable<T>;
+};
+
+const NotYetRefPropertyControll = React.forwardRef(
+  (props: RefPropertyControllProps, ref: Ref<Record<string, unknown>>) => {
+    const transfer = useRef<unknown>(undefined as any);
+    const mutableRef = useMemo(() => decideMutableRef(ref), [ref]);
+
+    useEffect(() => {
+      mutableRef.current = initCurrent(mutableRef.current);
+      mutableRef.current[props.propertyName] = transfer.current;
+    }, [mutableRef, props.propertyName]);
+
+    return React.cloneElement(props.children, {
+      ref: transfer,
+      className: props.className,
+    });
+  }
+);
+
+const RefPropertyControll = memo(NotYetRefPropertyControll);
+RefPropertyControll.displayName = "RefPropertyControll";
+
+export { RefPropertyControll };

--- a/src/util/components/RefPropertyControll.tsx
+++ b/src/util/components/RefPropertyControll.tsx
@@ -1,3 +1,6 @@
+// Use if some values from Refs and components.
+// this is to gather values of Ref with an object.
+
 import React, { memo, useEffect, useMemo, useRef } from "react";
 // eslint-disable-next-line no-unused-vars
 import { Ref, HadChildComponentProps, RefComponentProps } from "../types";

--- a/src/util/components/TextReader.tsx
+++ b/src/util/components/TextReader.tsx
@@ -1,3 +1,9 @@
+// use if you want to take an input tag with Ref.
+// this can pass a getter to Ref.
+// So, you can take this when to want to take value;
+// For example, use with a form tag, and call getter
+// when the submit event occured.
+
 import React, { memo, useEffect, useRef } from "react";
 // eslint-disable-next-line no-unused-vars
 import { HadChildComponentProps, RefComponentProps } from "src/util/types";

--- a/src/util/components/TextReader.tsx
+++ b/src/util/components/TextReader.tsx
@@ -1,0 +1,25 @@
+import React, { memo, useEffect, useRef } from "react";
+// eslint-disable-next-line no-unused-vars
+import { HadChildComponentProps, RefComponentProps } from "src/util/types";
+import { passValueRef } from "src/util/passValueRef";
+
+const NotYetTextReader = React.forwardRef<
+  () => string,
+  HadChildComponentProps<RefComponentProps>
+>((props, ref) => {
+  const transfer = useRef<HTMLInputElement>(undefined as any);
+
+  useEffect(() => {
+    passValueRef(ref, () => transfer.current.value);
+  }, [ref]);
+
+  return React.cloneElement(props.children, {
+    className: props.className,
+    ref: transfer,
+  });
+});
+
+const TextReader = memo(NotYetTextReader);
+TextReader.displayName = "TextReader";
+
+export { TextReader };

--- a/src/util/components/index.ts
+++ b/src/util/components/index.ts
@@ -1,1 +1,2 @@
+export * from "./RefPropertyControll";
 export * from "./RefFunctionally";

--- a/src/util/components/index.ts
+++ b/src/util/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./RefPropertyControll";
 export * from "./RefFunctionally";
+export * from "./TextReader";

--- a/src/util/components/index.ts
+++ b/src/util/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./RefFunctionally";

--- a/src/util/decideMutableRef.ts
+++ b/src/util/decideMutableRef.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import { isMutableRef } from "./isMutableRef";
+// eslint-disable-next-line no-unused-vars
+import { Ref } from "./types";
+
+export const decideMutableRef = <T>(
+  ref: Ref<T>
+): React.MutableRefObject<T | null> => {
+  if (!isMutableRef(ref)) throw new Error("Pass mutable ref");
+  return ref;
+};

--- a/src/util/excludeNull.ts
+++ b/src/util/excludeNull.ts
@@ -1,0 +1,4 @@
+export const excludeNull = function <T>(arg: T) {
+  if (arg == null) throw new Error("This value includes null");
+  return arg as NonNullable<T>;
+};

--- a/src/util/getRefSetter.ts
+++ b/src/util/getRefSetter.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line no-unused-vars
+import { Ref } from "./types";
+
+export const getRefSetter = <T>(ref: Ref<T>) => {
+  if (ref == null) throw new Error("Pass ref");
+  let refSetter = ref as NonNullable<typeof ref>;
+  if (typeof ref !== "function") refSetter = (e: T) => (ref.current = e);
+  return refSetter as (instance: T) => void;
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,2 @@
 export * from "./getRefSetter";
+export * from "./isMutableRef";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -2,3 +2,4 @@ export * from "./getRefSetter";
 export * from "./isMutableRef";
 export * from "./decideMutableRef";
 export * from "./excludeNull";
+export * from "./passValueRef";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./getRefSetter";
 export * from "./isMutableRef";
+export * from "./decideMutableRef";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./getRefSetter";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
 export * from "./getRefSetter";
 export * from "./isMutableRef";
 export * from "./decideMutableRef";
+export * from "./excludeNull";

--- a/src/util/isMutableRef.ts
+++ b/src/util/isMutableRef.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-unused-vars
+import { Ref } from "./types";
+
+export const isMutableRef = function <T>(
+  ref: Ref<T>
+): ref is React.MutableRefObject<T | null> {
+  return ref != null && typeof ref !== "function";
+};

--- a/src/util/passValueRef.ts
+++ b/src/util/passValueRef.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-unused-vars
+import { Ref } from "./types";
+
+export const passValueRef = <T>(ref: Ref<T>, value: T) => {
+  if (ref == null) throw new Error("pass ref");
+  else if (typeof ref === "function") ref(value);
+  else ref.current = value;
+};

--- a/src/util/test/dom/getElementsFrom.ts
+++ b/src/util/test/dom/getElementsFrom.ts
@@ -1,0 +1,38 @@
+// Use this code when you write a test code, only.
+
+type Tags = keyof HTMLElementTagNameMap;
+
+const isLengthTruthy = (array: unknown[]) => array.length > 0;
+const checkLengthTruthy = (array: unknown[]) => {
+  if (!isLengthTruthy(array))
+    throw new Error("The Length of the array is zero");
+};
+
+// The class is for ElementSearcher.
+// Usually, it is returned as a search result.
+class Elements<T extends Tags> extends Array<HTMLElementTagNameMap[T]> {
+  constructor(maybeArray: HTMLCollectionOf<HTMLElementTagNameMap[T]>) {
+    super(...Array.from(maybeArray));
+    Object.setPrototypeOf(this, Elements.prototype);
+  }
+
+  asSingle() {
+    checkLengthTruthy(this);
+    if (this.length > 1)
+      throw new Error("Search result is more than number which you think");
+    return this[0];
+  }
+}
+
+class ElementSearcher {
+  constructor(private readonly container: HTMLElement) {}
+
+  byTagName<T extends Tags>(tagName: T) {
+    const els = this.container.getElementsByTagName(tagName);
+    return new Elements(els);
+  }
+}
+
+export const getElementsFrom = (
+  container = (document as unknown) as HTMLElement
+) => new ElementSearcher(container);

--- a/src/util/test/dom/index.ts
+++ b/src/util/test/dom/index.ts
@@ -1,1 +1,2 @@
 export * from "./getElementsFrom";
+export * from "./renderDomFactory";

--- a/src/util/test/dom/index.ts
+++ b/src/util/test/dom/index.ts
@@ -1,0 +1,1 @@
+export * from "./getElementsFrom";

--- a/src/util/test/dom/renderDomFactory.tsx
+++ b/src/util/test/dom/renderDomFactory.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+export const renderDomFactory = function <
+  T extends Record<string, unknown>,
+  U extends Partial<T>
+>(elements: React.ReactElement, getProps: () => T = () => ({} as T)) {
+  return (options = {} as U) => {
+    const props = getProps();
+    const passedElements = React.cloneElement(elements, {
+      ...props,
+      ...options,
+    });
+    const domTree = render(passedElements);
+    return { container: domTree.container, props: { ...props, ...options } };
+  };
+};

--- a/src/util/test/dom/renderDomFactory.tsx
+++ b/src/util/test/dom/renderDomFactory.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-export const renderDomFactory = function <
-  T extends Record<string, unknown>,
-  U extends Partial<T>
->(elements: React.ReactElement, getProps: () => T = () => ({} as T)) {
+export const renderDomFactory = function <T, U extends Partial<T>>(
+  elements: React.ReactElement,
+  getProps: () => T = () => ({} as T)
+) {
   return (options = {} as U) => {
     const props = getProps();
     const passedElements = React.cloneElement(elements, {

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line no-unused-vars
+import { MutableRefObject, ReactElement } from "react";
+
+export type Ref<T> =
+  | ((instance: T) => void)
+  | MutableRefObject<T | null>
+  | null;
+
+interface BaseComponentProps {
+  className?: string;
+}
+
+export interface HadChildComponentProps<T = BaseComponentProps>
+  extends BaseComponentProps {
+  children: ReactElement<T>;
+}
+
+interface RefComponentProps<T = unknown> extends BaseComponentProps {
+  ref: Ref<T>;
+}

--- a/tests/util/components/RefFunctionally.test.tsx
+++ b/tests/util/components/RefFunctionally.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { mock } from "jest-mock-extended";
+import { RefFanctionally } from "src/util/components";
+import { getElementsFrom, renderDomFactory } from "src/util/test/dom";
+
+const getProps = () => ({
+  ref: mock<React.MutableRefObject<HTMLDivElement>>(),
+  className: "testcase",
+});
+
+const renderDom = renderDomFactory(
+  <RefFanctionally {...getProps()}>
+    <div />
+  </RefFanctionally>,
+  getProps
+);
+
+describe("Normal sytem", () => {
+  it("pass className", () => {
+    const {
+      container,
+      props: { className },
+    } = renderDom();
+    const div = getElementsFrom(container).byTagName("div").asSingle();
+    expect(div).toHaveProperty("className", className);
+  });
+
+  it("pass ref", () => {
+    const {
+      props: { ref },
+    } = renderDom();
+    expect(ref.current).toHaveProperty("tagName", "DIV");
+  });
+});

--- a/tests/util/components/RefPropertyControll.test.tsx
+++ b/tests/util/components/RefPropertyControll.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { mock } from "jest-mock-extended";
+import "@testing-library/jest-dom";
+import { RefPropertyControll } from "src/util/components";
+import { renderDomFactory, getElementsFrom } from "src/util/test/dom";
+
+const getProps = () => ({
+  ref: mock<React.MutableRefObject<Record<"div", HTMLDivElement>>>(),
+  className: "testcase",
+  propertyName: "div",
+});
+
+const renderDom = renderDomFactory(
+  <RefPropertyControll {...getProps()}>
+    <div />
+  </RefPropertyControll>,
+  getProps
+);
+
+describe("Normal system", () => {
+  it("add property", () => {
+    const {
+      props: { ref },
+    } = renderDom();
+    expect(ref.current).toHaveProperty("div");
+  });
+
+  it("pass ref", () => {
+    const {
+      props: { ref },
+    } = renderDom();
+    expect(ref.current.div).toHaveProperty("tagName", "DIV");
+  });
+
+  it("pass className", () => {
+    const className = "testClass";
+    const { container } = renderDom({ className });
+    const div = getElementsFrom(container).byTagName("div").asSingle();
+    expect(div.className).toEqual(className);
+  });
+});

--- a/tests/util/components/TextReader.test.tsx
+++ b/tests/util/components/TextReader.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { mock } from "jest-mock-extended";
+
+import { TextReader } from "src/util/components";
+import { renderDomFactory, getElementsFrom } from "src/util/test/dom";
+
+const getProps = () => ({ ref: mock<React.MutableRefObject<() => string>>() });
+
+const renderDom = renderDomFactory(
+  <TextReader>
+    <input />
+  </TextReader>,
+  getProps
+);
+
+const value = "testcase";
+
+const setValueInput = (el: HTMLElement, settedValue: string) => {
+  const input = getElementsFrom(el).byTagName("input").asSingle();
+  input.value = settedValue;
+};
+
+describe("Normal system", () => {
+  it("get getter", () => {
+    const {
+      props: { ref },
+    } = renderDom();
+    expect(ref.current).not.toThrow();
+    expect(ref.current()).toEqual("");
+  });
+
+  it("get value", () => {
+    const {
+      container,
+      props: { ref },
+    } = renderDom();
+    setValueInput(container, value);
+    expect(ref.current()).toEqual(value);
+  });
+});

--- a/tests/util/decideMutableRef.test.ts
+++ b/tests/util/decideMutableRef.test.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import { mock } from "jest-mock-extended";
+import { decideMutableRef } from "src/util";
+
+describe("Normal system", () => {
+  it("decide mutable", () => {
+    const ref = mock<React.MutableRefObject<any>>();
+    expect(() => decideMutableRef(ref)).not.toThrow();
+    expect(decideMutableRef(ref)).toEqual(ref);
+  });
+});
+
+describe("Exception system", () => {
+  it("pass function", () => {
+    const testcase = () => {
+      return;
+    };
+    expect(() => decideMutableRef(testcase)).toThrow();
+  });
+  it("pass null", () => {
+    expect(() => decideMutableRef(null)).toThrow();
+  });
+});

--- a/tests/util/excludeNull.test.ts
+++ b/tests/util/excludeNull.test.ts
@@ -1,0 +1,14 @@
+import { excludeNull } from "src/util";
+
+describe("Normal system", () => {
+  it("pass not nullable value", () => {
+    expect(() => excludeNull("not nullable")).not.toThrow();
+  });
+});
+
+describe("Exception system", () => {
+  it("pass nullable", () => {
+    expect(() => excludeNull(undefined)).toThrow();
+    expect(() => excludeNull(null)).toThrow();
+  });
+});

--- a/tests/util/getRefSetter.test.tsx
+++ b/tests/util/getRefSetter.test.tsx
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import { mock } from "jest-mock-extended";
+import { getRefSetter } from "src/util";
+
+describe("Normal system", () => {
+  it("trans function", () => {
+    const ref = mock<React.MutableRefObject<any>>();
+    const resSetter = getRefSetter(ref);
+    expect(resSetter).not.toHaveProperty("current");
+    expect(typeof resSetter).toEqual("function");
+  });
+});

--- a/tests/util/isMutableRef.test.ts
+++ b/tests/util/isMutableRef.test.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import { mock } from "jest-mock-extended";
+import { isMutableRef } from "src/util";
+
+describe("Normal system", () => {
+  it("function", () => {
+    const testcase = () => {
+      return;
+    };
+    expect(isMutableRef(testcase)).toBeFalsy();
+  });
+  it("null", () => {
+    expect(isMutableRef(null)).toBeFalsy();
+  });
+  it("mutable", () => {
+    const ref = mock<React.MutableRefObject<any>>();
+    expect(isMutableRef(ref)).toBeTruthy();
+  });
+});

--- a/tests/util/passValueRef.test.ts
+++ b/tests/util/passValueRef.test.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import { mock } from "jest-mock-extended";
+import { passValueRef } from "src/util";
+
+const value = 1;
+
+describe("Normal system", () => {
+  it("pass ref", () => {
+    const ref = mock<React.MutableRefObject<number>>();
+    passValueRef(ref, value);
+    expect(ref.current).toEqual(value);
+  });
+
+  it("pass function", () => {
+    const setter = jest.fn();
+    passValueRef(setter, value);
+    expect(setter).toBeCalledWith(value);
+  });
+});
+
+describe("Exception system", () => {
+  it("pass null", () => {
+    expect(() => passValueRef(null, value)).toThrow();
+  });
+});

--- a/tests/util/test/dom/getElementsBy.test.tsx
+++ b/tests/util/test/dom/getElementsBy.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+// for to leave screen to debug
+// eslint-disable-next-line no-unused-vars
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { getElementsFrom } from "src/util/test/dom";
+
+describe("Normal system", () => {
+  it("result is array", () => {
+    render(<div />);
+    const result = getElementsFrom().ByTagName("div");
+    expect(Array.isArray(result)).toBeTruthy();
+  });
+
+  it("get divs", () => {
+    const { container } = render(
+      <>
+        <div />
+        <div />
+        <div />
+      </>
+    );
+
+    expect(getElementsFrom(container).ByTagName("div")).toHaveLength(3);
+    expect(getElementsFrom().ByTagName("div")).toHaveLength(4);
+  });
+
+  it("get div", () => {
+    const { container } = render(<div />);
+
+    const divs = getElementsFrom(container).ByTagName("div");
+    expect(() => divs.first()).not.toThrow();
+    expect(divs.first()).toHaveProperty("tagName", "DIV");
+  });
+});

--- a/tests/util/test/dom/getElementsFrom.test.tsx
+++ b/tests/util/test/dom/getElementsFrom.test.tsx
@@ -8,7 +8,7 @@ import { getElementsFrom } from "src/util/test/dom";
 describe("Normal system", () => {
   it("result is array", () => {
     render(<div />);
-    const result = getElementsFrom().ByTagName("div");
+    const result = getElementsFrom().byTagName("div");
     expect(Array.isArray(result)).toBeTruthy();
   });
 
@@ -21,15 +21,15 @@ describe("Normal system", () => {
       </>
     );
 
-    expect(getElementsFrom(container).ByTagName("div")).toHaveLength(3);
-    expect(getElementsFrom().ByTagName("div")).toHaveLength(4);
+    expect(getElementsFrom(container).byTagName("div")).toHaveLength(3);
+    expect(getElementsFrom().byTagName("div")).toHaveLength(4);
   });
 
   it("get div", () => {
     const { container } = render(<div />);
 
-    const divs = getElementsFrom(container).ByTagName("div");
-    expect(() => divs.first()).not.toThrow();
-    expect(divs.first()).toHaveProperty("tagName", "DIV");
+    const divs = getElementsFrom(container).byTagName("div");
+    expect(() => divs.asSingle()).not.toThrow();
+    expect(divs.asSingle()).toHaveProperty("tagName", "DIV");
   });
 });

--- a/tests/util/test/dom/renderDomFactory.test.tsx
+++ b/tests/util/test/dom/renderDomFactory.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { renderDomFactory } from "src/util/test/dom";
+
+const getProps = () => ({ className: "testcase" });
+const renderDom = renderDomFactory(<div />, getProps);
+
+describe("Normal system", () => {
+  it("call function made without error", () => {
+    expect(renderDom).not.toThrow();
+  });
+
+  it("render dom", () => {
+    const {
+      container,
+      props: { className },
+    } = renderDom();
+    const div = container.getElementsByTagName("div")[0];
+    expect(div).toHaveProperty("className", className);
+  });
+});


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#22 への対応の中途確認。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
基礎的なUtilの追加。

## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->
今回の実装途中で気付いたのだが、Reactにおいてコンポーネントに文字列のプロパティを渡すとき、string literal typeの型で渡すことができない。つまり、"str"という文字列を渡してもstring型になり、"str"型にならない。  
他にもchildrenに対する型チェックがほぼないなど、ReactとTypeScriptの親和性の悪さをUtilを組む上でとても強く感じた。  
そこでいくつか追加したコンポーネントにおいては厳密な型チェックを行わず、unknownを多用している。  
そういった、ある意味でJavaScriptライクなTypeScriptの書き方について、どれほど容認するかの意見を含めてレビューしてほしい。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
utilを追加しただけでどこからもコールされていないため、影響はしない。テストにおいてはjestで実行することができる。
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし。
## 補足
<!-- ローカル環境で試す際の注意点、など -->
この後#22 にある、共通部分を直接解決するためのUtilを組んだプルリクエストや、それらUtilを実際に適用し、何か仕様の変わる部分などあればテストを調整したプルリクエストを出す。