### PR TITLE
fix: change .envfile path

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -72,7 +72,7 @@ const getEnvFilepath = (config: Env): string => {
   if (config.master) {
     envPath = path.resolve(__dirname, ".env.production");
   } else if (config.develop) {
-    envPath = path.resolve(__dirname, ".env.develop");
+    envPath = path.resolve(__dirname, ".env.development");
   } else {
     envPath = path.resolve(__dirname, ".env.feature");
   }


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
「build:develop」で動かしたとき、webpackで使用するenvファイルが存在しない。卍マジ卍

@NULL-header から指摘貰ったよ。ありがとう。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
developで指定するときのファイル名を変更。

## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->
ナッシング

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
build:developの時にWebpackが動いてちゃんとデプロイ対象が生成される。

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし

## 補足
<!-- ローカル環境で試す際の注意点、など -->
下記パターンを確認しました。
生成されたBundle.jsのbaseUrlに下記のドメインが入っていることを確認。

|コマンド|URI|
|:-|:-|
|yarn build:master|https://api.4ecode.com|
|yarn build:develop|https://dev.api.4ecode.com|
|yarn build:feature|https://dev.api.4ecode.com|

PR作成時にテーブルが崩れていた。卍マジ卍