### PR TITLE
Feature/#60 activate get props

### DIFF
--- a/src/FecApiWrapper/APITypes.d.ts
+++ b/src/FecApiWrapper/APITypes.d.ts
@@ -1,9 +1,13 @@
 type Status = "SUCCESS" | "FAILED" | "OLD_TOKEN" | "ERROR";
 type BadStatus = "FAILED" | "OLD_TOKEN" | "ERROR";
 
+interface BaseBody {
+  message: string;
+}
+
 export interface BaseResponse {
   status: Status;
-  body: unknown;
+  body: BaseBody;
   httpStatus: number;
 }
 
@@ -16,7 +20,6 @@ interface APIError {
 export interface BadResponse extends BaseResponse {
   status: BadStatus;
   body: null;
-  message: string;
   errors: APIError[];
 }
 
@@ -29,7 +32,7 @@ interface Tokens {
   onetime: string;
 }
 
-interface AuthPostFBody {
+interface AuthPostFBody extends BaseBody {
   token: Tokens;
 }
 
@@ -37,10 +40,6 @@ export interface AuthPostResponse extends GoodResponse {
   body: AuthPostFBody;
 }
 
-interface UsersPostFBody {
-  message: string;
-}
+export type UsersPostResponse = GoodResponse;
 
-export interface UsersPostResponse extends GoodResponse {
-  body: UsersPostFBody;
-}
+export type ActivatePutResponse = GoodResponse;

--- a/src/FecApiWrapper/index.ts
+++ b/src/FecApiWrapper/index.ts
@@ -6,18 +6,20 @@ import {
   // eslint-disable-next-line no-unused-vars
   BadResponse,
   // eslint-disable-next-line no-unused-vars
-  BaseResponse,
+  GoodResponse,
   // eslint-disable-next-line no-unused-vars
   UsersPostResponse,
   // eslint-disable-next-line no-unused-vars
   Tokens,
+  // eslint-disable-next-line no-unused-vars
+  ActivatePutResponse,
 } from "./APITypes";
 
 const apiUrl = CONSTVALUES.baseUrl + CONSTVALUES.apiv1;
 const tokenGuard = new TokenGuard();
 
 export const isBadResponse = (
-  arg: BaseResponse | BadResponse
+  arg: GoodResponse | BadResponse
 ): arg is BadResponse => {
   return arg.status !== "SUCCESS";
 };
@@ -31,7 +33,7 @@ const setTokensCache = ({ onetime, master }: Tokens) => {
 export class FecApiWrapper {
   private readonly abortCtl = new AbortController();
 
-  async fetch<T = BaseResponse>(
+  async fetch<T extends GoodResponse>(
     path: string,
     value: Record<string, unknown>,
     option?: RequestInit
@@ -84,6 +86,15 @@ export class FecApiWrapper {
       { token: onetime },
       { method: "DELETE" }
     );
+    return res;
+  }
+
+  async activateUser(argObj: { token: string; email: string }) {
+    const res = await this.fetch<ActivatePutResponse>(
+      CONSTVALUES.activate,
+      { value: argObj },
+      { method: "PUT" }
+    ).catch((e) => undefined);
     return res;
   }
 }

--- a/src/components/ActivateContainer/ActivateContainer.tsx
+++ b/src/components/ActivateContainer/ActivateContainer.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo, useState, useCallback } from "react";
+
+import { FecApiWrapper, isBadResponse } from "src/FecApiWrapper";
+import { useApi } from "src/customhook";
+import { useCurrent } from "src/util/customhook";
+import { AgreeForm } from "./AgreeForm";
+import { BadAccessGuard } from "./BadAccessGuard";
+// eslint-disable-next-line no-unused-vars
+import { Warning, Queries } from "./types";
+
+interface Current {
+  isFired: boolean;
+  wasActivated: boolean;
+  warning: Warning;
+  isShownLabel: boolean;
+  queryRecord: Queries;
+}
+
+type UnPromisify<T> = T extends Promise<infer U> ? U : T;
+
+type AsyncReturnType<T extends (...args: any) => Promise<any>> = UnPromisify<
+  ReturnType<T>
+>;
+
+type Responses = AsyncReturnType<typeof FecApiWrapper.prototype.activateUser>;
+
+const defaultStates = [
+  {
+    wasActivated: false,
+    warning: "noCommunicate",
+    isShownLabel: false,
+    queryRecord: {} as Queries,
+  },
+] as Current[];
+
+const getWarning = (res: Responses): Warning => {
+  let warning: Warning = "unknown";
+  if (res == null) warning = "noCommunicate";
+  else if (isBadResponse(res)) {
+    warning = "missAuth";
+  }
+  return warning;
+};
+
+const Component: React.FC<BaseComponentProps> = (props) => {
+  const [states, setStates] = useState(defaultStates);
+  const current = useCurrent(states);
+  const { wasActivated, warning, isShownLabel } = current;
+  const api = useMemo(() => new FecApiWrapper(), []);
+
+  const insertState = useCallback(
+    (arg: Current) => setStates([Object.assign({}, current, arg)]),
+    [current]
+  );
+
+  const onClick = useCallback(
+    (_, queryRecord: Queries) => insertState({ queryRecord } as Current),
+    [insertState]
+  );
+
+  useApi(
+    async (isMounted, didMounted) => {
+      if (!didMounted()) return;
+      insertState({ isShownLabel: false } as Current);
+      const res = await api.activateUser(current.queryRecord);
+      console.log({ res });
+      const warning = getWarning(res);
+      const next = { warning } as Current;
+      if (res != null && !isBadResponse(res)) next.wasActivated = true;
+      else next.isShownLabel = true;
+      if (isMounted()) insertState(next);
+    },
+    api,
+    [current.queryRecord, api]
+  );
+
+  return (
+    <BadAccessGuard>
+      <AgreeForm {...{ isShownLabel, warning, wasActivated, onClick }} />
+    </BadAccessGuard>
+  );
+};
+
+const ActivateContainer = React.memo(Component);
+ActivateContainer.displayName = "ActivateContainer";
+
+export { ActivateContainer };

--- a/src/components/ActivateContainer/AgreeForm.tsx
+++ b/src/components/ActivateContainer/AgreeForm.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback } from "react";
+
+import { ToggleDisplayContainer, LinkButton } from "src/components";
+
+import { WarningState } from "./WarningState";
+// eslint-disable-next-line no-unused-vars
+import { Queries, Warning } from "./types";
+import { useQueryRecord } from "./useQueryRecord";
+
+interface Props extends BaseComponentProps {
+  onClick: (
+    event: React.MouseEvent<HTMLButtonElement, React.MouseEvent>,
+    queries: Queries
+  ) => void;
+  isShownLabel: boolean;
+  warning: Warning;
+  wasActivated: boolean;
+}
+
+const Component: React.FC<Props> = (props) => {
+  const { onClick, warning, isShownLabel, wasActivated } = props;
+  const queryRecord = useQueryRecord();
+  const handleClick = useCallback(
+    (e: any) => {
+      return onClick(e, queryRecord as any);
+    },
+    [onClick, queryRecord]
+  );
+
+  return (
+    <ToggleDisplayContainer isShownFirstChild={wasActivated}>
+      <div>
+        <div>認証に成功しました。</div>
+        <LinkButton to="/login">Login</LinkButton>
+      </div>
+      <div>
+        <div>ここに規約が入る</div>
+        <WarningState isShown={isShownLabel} warning={warning} />
+        <button onClick={handleClick}>同意する</button>
+      </div>
+    </ToggleDisplayContainer>
+  );
+};
+
+const AgreeForm = React.memo(Component);
+AgreeForm.displayName = "AgreeForm";
+
+export { AgreeForm };

--- a/src/components/ActivateContainer/BadAccessGuard.tsx
+++ b/src/components/ActivateContainer/BadAccessGuard.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from "react";
+import { Redirect } from "react-router-dom";
+
+import { mapAttr } from "src/util";
+
+// eslint-disable-next-line no-unused-vars
+import { Queries } from "./types";
+import { useQueryRecord } from "./useQueryRecord";
+
+const areTrueAll = (arg: Record<string, boolean>) =>
+  Object.values(arg).findIndex((e) => !e) === -1;
+
+const areNonNullableProps = function <T extends Record<any, unknown>>(obj: T) {
+  return areTrueAll(mapAttr(obj, (e) => e != null));
+};
+
+interface Props extends BaseComponentProps {
+  children: React.ReactNode;
+}
+
+const Component: React.FC<Props> = (props) => {
+  const queryRecord = useQueryRecord();
+  const rendered = useMemo(() => {
+    let rendered: React.ReactNode = <Redirect to="/home" />;
+    if (areNonNullableProps(queryRecord as any)) rendered = props.children;
+    return rendered;
+  }, [props.children, queryRecord]);
+  return rendered as any;
+};
+
+const BadAccessGuard = React.memo(Component);
+BadAccessGuard.displayName = "BadAccessGuard";
+
+export { BadAccessGuard };

--- a/src/components/ActivateContainer/WarningState.tsx
+++ b/src/components/ActivateContainer/WarningState.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { DisplayContainer, WarningLabel } from "src/components";
+
+// eslint-disable-next-line no-unused-vars
+import { Warning } from "./types";
+
+interface Props extends BaseComponentProps {
+  warning: Warning;
+  isShown: boolean;
+}
+
+const Component: React.FC<Props> = (props) => {
+  const { warning, isShown, className } = props;
+  return (
+    <WarningLabel {...{ isShown, className }}>
+      <DisplayContainer currentKey={warning}>
+        <div key="noCommunicate">サーバーとの通信に失敗しました。</div>
+        <div key="missAuth">
+          有効なURLではありませんでした。再度アカウントを作成してください。
+        </div>
+        <div key="unknown">未知のエラーが発生しました。</div>
+      </DisplayContainer>
+    </WarningLabel>
+  );
+};
+
+const WarningState = React.memo(Component);
+WarningState.displayName = "WarningState";
+
+export { WarningState };

--- a/src/components/ActivateContainer/index.ts
+++ b/src/components/ActivateContainer/index.ts
@@ -1,0 +1,1 @@
+export * from "./ActivateContainer";

--- a/src/components/ActivateContainer/types.d.ts
+++ b/src/components/ActivateContainer/types.d.ts
@@ -1,0 +1,5 @@
+export type Warning = "noCommunicate" | "missAuth" | "unknown";
+export interface Queries {
+  token: string;
+  email: string;
+}

--- a/src/components/ActivateContainer/useQueryRecord.ts
+++ b/src/components/ActivateContainer/useQueryRecord.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "src/util/customhook";
+
+const queryKeys = ["token", "email"];
+
+export const useQueryRecord = () => {
+  const queryMap = useQuery();
+  return queryKeys.reduce((a, e) => {
+    a[e] = queryMap.get(e);
+    return a;
+  }, {} as Record<string, string | null>);
+};

--- a/src/components/AnonymousContainer/AnonymousContainer.tsx
+++ b/src/components/AnonymousContainer/AnonymousContainer.tsx
@@ -7,6 +7,7 @@ import {
   SignupContainer,
   LinkButton,
   SwitchContainer,
+  ActivateContainer,
 } from "src/components";
 import { styles } from "./style";
 
@@ -19,7 +20,8 @@ const components = {
   "/search": () => <div>Search</div>,
   "/login": LoginContainer,
   "/signup": SignupContainer,
-} as Record<string, React.FC>;
+  "/account/activate/": ActivateContainer,
+} as Record<string, React.FC<any>>;
 
 const Component: React.FC<Props> = (props) => {
   return (
@@ -27,8 +29,8 @@ const Component: React.FC<Props> = (props) => {
       <SideBar className={props.classes.sidebar}>
         <LinkButton to="/home">Home</LinkButton>
         <LinkButton to="/search">Search</LinkButton>
-        <LinkButton to="login">Log in</LinkButton>
-        <LinkButton to="signup">Sign up</LinkButton>
+        <LinkButton to="/login">Log in</LinkButton>
+        <LinkButton to="/signup">Sign up</LinkButton>
       </SideBar>
       <SwitchContainer components={components} />
     </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,6 @@
 export * from "./AppContainer";
+// order for circular dependensices
+export * from "./ActivateContainer";
 export * from "./SignupContainer";
 export * from "./DisplayContainer";
 export * from "./LoginContainer";

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,4 +4,5 @@ export const CONSTVALUES = {
   apiv1: "/api/v1/",
   auth: "auth",
   users: "users",
+  activate: "account_activations",
 } as const;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -25,7 +25,7 @@ const webpackConfig = (env: Env): webpack.Configuration => ({
   output: {
     path: path.join(__dirname, "/public"),
     filename: "bundle.js",
-    publicPath: "/",
+    publicPath: "/" + ((e) => (e == null ? "" : e))(env.branchName),
   },
   devServer: {
     historyApiFallback: true,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -25,7 +25,8 @@ const webpackConfig = (env: Env): webpack.Configuration => ({
   output: {
     path: path.join(__dirname, "/public"),
     filename: "bundle.js",
-    publicPath: "/" + ((e) => (e == null ? "" : e))(env.branchName),
+    publicPath:
+      "/" + ((e) => (e == null ? "" : encodeURIComponent(e)))(env.branchName),
   },
   devServer: {
     historyApiFallback: true,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -25,6 +25,7 @@ const webpackConfig = (env: Env): webpack.Configuration => ({
   output: {
     path: path.join(__dirname, "/public"),
     filename: "bundle.js",
+    publicPath: "/",
   },
   devServer: {
     historyApiFallback: true,


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#60 への対応
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* webpack-dev-server実行時にネストしたルーティングができない問題の解決
* APIのラッパーにアカウントのアクティベイト用メソッドの追加
* アクティベイト用のルーティング
## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->
特になし。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
* アカウントのアクティベイト用のHTMLをバックエンドに置かなくてもいいようになった
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし。
## 補足
<!-- ローカル環境で試す際の注意点、など -->
以下がブランチのデプロイ先のURLになる。
https://feature.4ecode.com/%2360-activate-getProps/
しかし、アカウントをアクティベイトする用のページに飛ぶボタンはないので、以下のページにアクセスするとよい。
https://feature.4ecode.com/%2360-activate-getProps/account/activate/?token=AAA&email=BBB
tokenとemailは適宜調整するように。