### PR TITLE
Feature/#81 redirect after login make

### DIFF
--- a/src/components/ContentContainer/ContentContainer.tsx
+++ b/src/components/ContentContainer/ContentContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 
 import {
   AnonymousContainer,
@@ -6,14 +6,40 @@ import {
   ToggleDisplayContainer,
 } from "src/components";
 import { isLogin } from "src/FecApiWrapper";
+import { useCurrent } from "src/util/customhook";
+
+import { LoginStateContext } from "./context";
+
+interface Current {
+  isLogin: boolean;
+}
 
 const Component: React.FC<BaseComponentProps> = (props) => {
-  const wasLogin = useMemo(() => isLogin(), []);
+  const [states, setStates] = useState([{ isLogin: isLogin() } as Current]);
+  const current = useCurrent(states);
+
+  const insertState = useCallback(
+    (arg: Current) => setStates([Object.assign({}, current, arg)]),
+    [current]
+  );
+
+  const setIsLogin = useCallback(
+    (arg: boolean) => insertState({ isLogin: arg } as Current),
+    [insertState]
+  );
+
+  const loginState = useMemo(() => ({ isLogin: current.isLogin, setIsLogin }), [
+    current.isLogin,
+    setIsLogin,
+  ]);
+
   return (
-    <ToggleDisplayContainer isShownFirstChild={wasLogin}>
-      <OnymousContainer />
-      <AnonymousContainer />
-    </ToggleDisplayContainer>
+    <LoginStateContext.Provider value={loginState}>
+      <ToggleDisplayContainer isShownFirstChild={current.isLogin}>
+        <OnymousContainer />
+        <AnonymousContainer />
+      </ToggleDisplayContainer>
+    </LoginStateContext.Provider>
   );
 };
 

--- a/src/components/ContentContainer/context.ts
+++ b/src/components/ContentContainer/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+const defaultValue = {
+  isLogin: false,
+  setIsLogin: (arg: boolean) => {
+    return;
+  },
+};
+
+export const LoginStateContext = createContext(defaultValue);

--- a/src/components/LoginContainer/LoginContainer.tsx
+++ b/src/components/LoginContainer/LoginContainer.tsx
@@ -1,10 +1,12 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState, useContext } from "react";
+import { useHistory } from "react-router-dom";
 
 // eslint-disable-next-line no-unused-vars
 import { BaseComponentProps } from "src/util/types";
 import { useVariable, useCurrent } from "src/util/customhook";
 import { useApi } from "src/customhook";
 import { FecApiWrapper, isBadResponse } from "src/FecApiWrapper";
+import { LoginStateContext } from "src/components/ContentContainer/context";
 
 // eslint-disable-next-line no-unused-vars
 import { Infos, LoginForm } from "./LoginForm";
@@ -50,6 +52,8 @@ const Component: React.FC<BaseComponentProps> = (props) => {
   const warningKey = useVariable(current.warningKey);
   const className = useVariable(props.className);
   const api = useMemo(() => new FecApiWrapper(), []);
+  const loginState = useContext(LoginStateContext);
+  const history = useHistory();
 
   const insertState = useCallback(
     (arg: Current) => setStates([Object.assign({}, current, arg)]),
@@ -76,7 +80,11 @@ const Component: React.FC<BaseComponentProps> = (props) => {
         isShownLabel: true,
         warningKey: getKeyFromRes(res),
       } as Current;
-      if (isMounted()) insertState(next);
+      if (isMounted()) {
+        insertState(next);
+        loginState.setIsLogin(true);
+        history.push("/home");
+      }
     },
     api,
     [current.infos]


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#81 への対応。
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* contextの追加
* Login時にhomeにリダイレクトする処理の追加
* Login判定にグローバル変数として用意したcontextを使用
## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->
特になし。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
今後のログイン周りの操作。
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし。
## 補足
<!-- ローカル環境で試す際の注意点、など -->
URLは以下。
https://feature.4ecode.com/%2381-redirectAfterLogin-make/login
ログアウトしてから試す必要がある。